### PR TITLE
Disk-Fill experiment has been added for Sock-Shop against Catalogue-DB

### DIFF
--- a/workflows/sock-shop-demo/usingCmdProbe/workflow.yaml
+++ b/workflows/sock-shop-demo/usingCmdProbe/workflow.yaml
@@ -30,6 +30,8 @@ spec:
             template: pod-delete
         - - name: pod-network-loss
             template: pod-network-loss
+        - - name: disk-fill
+            template: disk-fill   
         - - name: revert-chaos
             template: revert-chaos
         #  - name: delete-application
@@ -344,6 +346,80 @@ spec:
         image: litmuschaos/litmus-checker:latest
         args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"] 
 
+    - name: disk-fill
+      inputs:
+        artifacts:
+          - name: disk-fill
+            path: /tmp/chaosengine.yaml
+            raw:
+              data: |
+                apiVersion: litmuschaos.io/v1alpha1
+                kind: ChaosEngine
+                metadata:
+                  name: catalogue-disk-fill
+                  namespace: {{workflow.parameters.adminModeNamespace}}
+                spec:
+                  appinfo:
+                    appns: 'sock-shop'
+                    applabel: 'name=catalogue-db'
+                    appkind: 'statefulset'
+                  annotationCheck: 'false'
+                  engineState: 'active'
+                  chaosServiceAccount: litmus-admin
+                  monitoring: false
+                  jobCleanUpPolicy: 'retain'
+                  components:
+                    runner:
+                      imagePullPolicy: Always
+                  experiments:
+                    - name: disk-fill
+                      spec:
+                        probe:
+                        - name: "check-catalogue-db-cr-status"
+                          type: "k8sProbe"
+                          k8sProbe/inputs:
+                            command:
+                              group: ""
+                              version: "v1"
+                              resource: "pods"
+                              namespace: "sock-shop"
+                              fieldSelector: "status.phase=Running"
+                              labelSelector: "name=catalogue-db"
+                          operation: "present"
+                          mode: "Continuous"
+                          runProperties:
+                            probeTimeout: 1
+                            interval: 1
+                            retry: 1
+                            probePollingInterval: 1
+                        - name: "check-benchmark"
+                          type: "cmdProbe"
+                          cmdProbe/inputs:
+                            command: "curl http://qps-test.sock-shop.svc.cluster.local:80"
+                            comparator:
+                              type: "int" # supports: string, int, float
+                              criteria: ">=" #supports >=,<=,>,<,==,!= for int and contains,equal,notEqual,matches,notMatches for string values
+                              value: "500"
+                            source: "inline" # it can be “inline” or any image
+                          mode: "Edge"
+                          runProperties:
+                            probeTimeout: 2
+                            interval: 2
+                            retry: 1
+                            initialDelaySeconds: 1
+                        components:
+                          env:
+                            - name: FILL_PERCENTAGE
+                              value: '100'
+                
+                            - name: TARGET_CONTAINER
+                              value: ''
+                            - name: TOTAL_CHAOS_DURATION
+                              value: '60'                            
+      container:
+        image: litmuschaos/litmus-checker:latest
+        args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"]
+
     - name: delete-application
       container:
         image: litmuschaos/litmus-app-deployer:latest
@@ -361,7 +437,7 @@ spec:
     
     - name: revert-chaos
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args: 
           [ 

--- a/workflows/sock-shop-demo/usingCmdProbe/workflow_cron.yaml
+++ b/workflows/sock-shop-demo/usingCmdProbe/workflow_cron.yaml
@@ -34,6 +34,8 @@ spec:
             template: pod-delete
         - - name: pod-network-loss
             template: pod-network-loss
+        - - name: disk-fill
+            template: disk-fill  
         - - name: revert-chaos
             template: revert-chaos
         #  - name: delete-application
@@ -348,6 +350,80 @@ spec:
         image: litmuschaos/litmus-checker:latest
         args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"] 
 
+    - name: disk-fill
+      inputs:
+        artifacts:
+          - name: disk-fill
+            path: /tmp/chaosengine.yaml
+            raw:
+              data: |
+                apiVersion: litmuschaos.io/v1alpha1
+                kind: ChaosEngine
+                metadata:
+                  name: catalogue-disk-fill
+                  namespace: {{workflow.parameters.adminModeNamespace}}
+                spec:
+                  appinfo:
+                    appns: 'sock-shop'
+                    applabel: 'name=catalogue-db'
+                    appkind: 'statefulset'
+                  annotationCheck: 'false'
+                  engineState: 'active'
+                  chaosServiceAccount: litmus-admin
+                  monitoring: false
+                  jobCleanUpPolicy: 'retain'
+                  components:
+                    runner:
+                      imagePullPolicy: Always
+                  experiments:
+                    - name: disk-fill
+                      spec:
+                        probe:
+                        - name: "check-catalogue-db-cr-status"
+                          type: "k8sProbe"
+                          k8sProbe/inputs:
+                            command:
+                              group: ""
+                              version: "v1"
+                              resource: "pods"
+                              namespace: "sock-shop"
+                              fieldSelector: "status.phase=Running"
+                              labelSelector: "name=catalogue-db"
+                          operation: "present"
+                          mode: "Continuous"
+                          runProperties:
+                            probeTimeout: 1
+                            interval: 1
+                            retry: 1
+                            probePollingInterval: 1
+                        - name: "check-benchmark"
+                          type: "cmdProbe"
+                          cmdProbe/inputs:
+                            command: "curl http://qps-test.sock-shop.svc.cluster.local:80"
+                            comparator:
+                              type: "int" # supports: string, int, float
+                              criteria: ">=" #supports >=,<=,>,<,==,!= for int and contains,equal,notEqual,matches,notMatches for string values
+                              value: "500"
+                            source: "inline" # it can be “inline” or any image
+                          mode: "Edge"
+                          runProperties:
+                            probeTimeout: 2
+                            interval: 2
+                            retry: 1
+                            initialDelaySeconds: 1
+                        components:
+                          env:
+                            - name: FILL_PERCENTAGE
+                              value: '100'
+                
+                            - name: TARGET_CONTAINER
+                              value: ''
+                            - name: TOTAL_CHAOS_DURATION
+                              value: '60'                            
+      container:
+        image: litmuschaos/litmus-checker:latest
+        args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"]
+
     - name: delete-application
       container:
         image: litmuschaos/litmus-app-deployer:latest
@@ -365,7 +441,7 @@ spec:
     
     - name: revert-chaos
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args: 
           [ 

--- a/workflows/sock-shop-demo/usingPromProbe/workflow.yaml
+++ b/workflows/sock-shop-demo/usingPromProbe/workflow.yaml
@@ -30,6 +30,8 @@ spec:
             template: pod-delete
         - - name: pod-network-loss
             template: pod-network-loss
+        - - name: disk-fill
+            template: disk-fill 
         - - name: revert-chaos
             template: revert-chaos
         #  - name: delete-application
@@ -338,6 +340,78 @@ spec:
         image: litmuschaos/litmus-checker:latest
         args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"]
     
+    - name: disk-fill
+      inputs:
+        artifacts:
+          - name: disk-fill
+            path: /tmp/chaosengine.yaml
+            raw:
+              data: |
+                apiVersion: litmuschaos.io/v1alpha1
+                kind: ChaosEngine
+                metadata:
+                  name: catalogue-disk-fill
+                  namespace: {{workflow.parameters.adminModeNamespace}}
+                spec:
+                  appinfo:
+                    appns: 'sock-shop'
+                    applabel: 'name=catalogue-db'
+                    appkind: 'statefulset'
+                  annotationCheck: 'false'
+                  engineState: 'active'
+                  chaosServiceAccount: litmus-admin
+                  monitoring: false
+                  jobCleanUpPolicy: 'retain'
+                  components:
+                    runner:
+                      imagePullPolicy: Always
+                  experiments:
+                    - name: disk-fill
+                      spec:
+                        probe:
+                        - name: "check-catalogue-db-cr-status"
+                          type: "k8sProbe"
+                          k8sProbe/inputs:
+                            command:
+                              group: ""
+                              version: "v1"
+                              resource: "pods"
+                              namespace: "sock-shop"
+                              fieldSelector: "status.phase=Running"
+                              labelSelector: "name=catalogue-db"
+                          operation: "present"
+                          mode: "Continuous"
+                          runProperties:
+                            probeTimeout: 1
+                            interval: 1
+                            retry: 1
+                            probePollingInterval: 1
+                        - name: "check-probe-success"
+                          type: "promProbe"
+                          promProbe/inputs:
+                            endpoint: "http://prometheus.monitoring.svc.cluster.local:9090"
+                            query: "sum(rate(request_duration_seconds_count{job='sock-shop/front-end',route='/',status_code='200'}[20s]))*100"
+                            comparator:
+                              criteria: ">=" #supports >=,<=,>,<,==,!= comparision
+                              value: "500"
+                          mode: "Edge"
+                          runProperties:  
+                            probeTimeout: 5
+                            interval: 5
+                            retry: 1
+                        components:
+                          env:
+                            - name: FILL_PERCENTAGE
+                              value: '100'
+                
+                            - name: TARGET_CONTAINER
+                              value: ''
+                            - name: TOTAL_CHAOS_DURATION
+                              value: '60'                            
+      container:
+        image: litmuschaos/litmus-checker:latest
+        args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"]
+    
     - name: delete-application
       container:
         image: litmuschaos/litmus-app-deployer:latest
@@ -355,7 +429,7 @@ spec:
     
     - name: revert-chaos
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args: 
           [ 

--- a/workflows/sock-shop-demo/usingPromProbe/workflow_cron.yaml
+++ b/workflows/sock-shop-demo/usingPromProbe/workflow_cron.yaml
@@ -35,7 +35,9 @@ spec:
         - - name: pod-delete
             template: pod-delete
         - - name: pod-network-loss
-            template: pod-network-loss   
+            template: pod-network-loss
+        - - name: disk-fill
+            template: disk-fill  
         - - name: revert-chaos
             template: revert-chaos
         #  - name: delete-application
@@ -343,6 +345,78 @@ spec:
         image: litmuschaos/litmus-checker:latest
         args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"]
     
+    - name: disk-fill
+      inputs:
+        artifacts:
+          - name: disk-fill
+            path: /tmp/chaosengine.yaml
+            raw:
+              data: |
+                apiVersion: litmuschaos.io/v1alpha1
+                kind: ChaosEngine
+                metadata:
+                  name: catalogue-disk-fill
+                  namespace: {{workflow.parameters.adminModeNamespace}}
+                spec:
+                  appinfo:
+                    appns: 'sock-shop'
+                    applabel: 'name=catalogue-db'
+                    appkind: 'statefulset'
+                  annotationCheck: 'false'
+                  engineState: 'active'
+                  chaosServiceAccount: litmus-admin
+                  monitoring: false
+                  jobCleanUpPolicy: 'retain'
+                  components:
+                    runner:
+                      imagePullPolicy: Always
+                  experiments:
+                    - name: disk-fill
+                      spec:
+                        probe:
+                        - name: "check-catalogue-db-cr-status"
+                          type: "k8sProbe"
+                          k8sProbe/inputs:
+                            command:
+                              group: ""
+                              version: "v1"
+                              resource: "pods"
+                              namespace: "sock-shop"
+                              fieldSelector: "status.phase=Running"
+                              labelSelector: "name=catalogue-db"
+                          operation: "present"
+                          mode: "Continuous"
+                          runProperties:
+                            probeTimeout: 1
+                            interval: 1
+                            retry: 1
+                            probePollingInterval: 1
+                        - name: "check-probe-success"
+                          type: "promProbe"
+                          promProbe/inputs:
+                            endpoint: "http://prometheus.monitoring.svc.cluster.local:9090"
+                            query: "sum(rate(request_duration_seconds_count{job='sock-shop/front-end',route='/',status_code='200'}[20s]))*100"
+                            comparator:
+                              criteria: ">=" #supports >=,<=,>,<,==,!= comparision
+                              value: "500"
+                          mode: "Edge"
+                          runProperties:  
+                            probeTimeout: 5
+                            interval: 5
+                            retry: 1
+                        components:
+                          env:
+                            - name: FILL_PERCENTAGE
+                              value: '100'
+                
+                            - name: TARGET_CONTAINER
+                              value: ''
+                            - name: TOTAL_CHAOS_DURATION
+                              value: '60'                            
+      container:
+        image: litmuschaos/litmus-checker:latest
+        args: ["-file=/tmp/chaosengine.yaml","-saveName=/tmp/engine-name"]
+
     - name: delete-application
       container:
         image: litmuschaos/litmus-app-deployer:latest
@@ -360,7 +434,7 @@ spec:
     
     - name: revert-chaos
       container:
-        image: lachlanevenson/k8s-kubectl
+        image: alpine/k8s:1.18.2
         command: [sh, -c]
         args: 
           [ 


### PR DESCRIPTION
Signed-off-by: oumkale <oum.kale@mayadata.io>

Disk-Fill experiment has been added for Sock-Shop against Catalogue-DB
Probes Used
 - k8sProbe for Running status of pod
 - cmdProbe against benchmark QPS 